### PR TITLE
Update to Stack LTS 20.3 with GHC 9.2.5

### DIFF
--- a/modulint.cabal
+++ b/modulint.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9a375d125018b23dfc48b72a3cc5deb7ca233888ead2efa50b1e94dda36bc6d7
+-- hash: 4f60224f1987fc20116b912fbd47b3f58e1c83db07c79147a17a861d4d7496fe
 
 name:           modulint
 version:        0.1.0.1
@@ -50,12 +50,12 @@ library
       base >=4.7 && <5
     , bytestring
     , containers ==0.6.*
-    , dhall >=1.28 && <1.41
+    , dhall >=1.28 && <1.42
     , directory ==1.3.*
     , file-embed ==0.0.*
     , filepath ==1.4.*
     , haskell-src-exts >=1.20 && <1.24
-    , optparse-applicative >=0.14 && <0.17
+    , optparse-applicative >=0.14 && <0.18
     , text
     , unix ==2.7.*
   default-language: Haskell2010
@@ -71,13 +71,13 @@ executable modulint
       base >=4.7 && <5
     , bytestring
     , containers ==0.6.*
-    , dhall >=1.28 && <1.41
+    , dhall >=1.28 && <1.42
     , directory ==1.3.*
     , file-embed ==0.0.*
     , filepath ==1.4.*
     , haskell-src-exts >=1.20 && <1.24
     , modulint
-    , optparse-applicative >=0.14 && <0.17
+    , optparse-applicative >=0.14 && <0.18
     , text
     , unix ==2.7.*
   default-language: Haskell2010
@@ -95,13 +95,13 @@ test-suite modulint-test
     , base >=4.7 && <5
     , bytestring
     , containers ==0.6.*
-    , dhall >=1.28 && <1.41
+    , dhall >=1.28 && <1.42
     , directory ==1.3.*
     , file-embed ==0.0.*
     , filepath ==1.4.*
     , haskell-src-exts >=1.20 && <1.24
     , modulint
-    , optparse-applicative >=0.14 && <0.17
+    , optparse-applicative >=0.14 && <0.18
     , text
     , unix ==2.7.*
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                modulint
-version:             0.1.0.1
+version:             0.1.0.2
 github:              "flipstone/modulint"
 license:             BSD3
 author:              "Flipstone Technology Partners"
@@ -23,12 +23,12 @@ dependencies:
 - base >= 4.7 && < 5
 - bytestring
 - containers >= 0.6 && < 0.7
-- dhall >= 1.28 && < 1.41
+- dhall >= 1.28 && < 1.42
 - directory >= 1.3 && < 1.4
 - file-embed >= 0.0 && < 0.1
 - filepath >= 1.4 && < 1.5
 - haskell-src-exts >= 1.20 && < 1.24
-- optparse-applicative >= 0.14 && < 0.17
+- optparse-applicative >= 0.14 && < 0.18
 - unix >= 2.7 && < 2.8
 - text
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-19.7
+resolver: lts-20.3
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 618884
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/7.yaml
-    sha256: 57d4ce67cc097fea2058446927987bc1f7408890e3a6df0da74e5e318f051c20
-  original: lts-19.7
+    sha256: 03cec7d96ed78877b03b5c2bc5e31015b47f69af2fe6a62d994a42b7a43c5805
+    size: 648659
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/3.yaml
+  original: lts-20.3


### PR DESCRIPTION
This updates modulint to a stack LTS that uses 9.2.5. Version bounds of dependencies were expanded to accoomdate newer versions of packages in this LTS. No other changes were necessary so only a minor version bump was needed.